### PR TITLE
Add support for MateBook D16 with AMD Ryzen 5 4600H (HVY-WXX9)

### DIFF
--- a/sound/soc/amd/acp3x-es8336.c
+++ b/sound/soc/amd/acp3x-es8336.c
@@ -294,6 +294,14 @@ static const struct dmi_system_id acp3x_es8336_dmi_table[] = {
 		},
 		.driver_data = &acp3x_es8336,
 	},
+		{
+		.matches = {
+			DMI_EXACT_MATCH(DMI_BOARD_VENDOR, "HUAWEI"),
+			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "HVY-WXX9"),
+			DMI_EXACT_MATCH(DMI_PRODUCT_VERSION, "M1040"),
+		},
+		.driver_data = &acp3x_es8336,
+	},
 	{}
 };
 


### PR DESCRIPTION
The laptop speakers work OK, but the jack doesn't seem to work: the sound is very quiet: you can barely hear it.